### PR TITLE
Add apt backports

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,7 @@ icinga2_agent_yum:
 icinga2_agent_apt:
   repo: "deb http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main"
   key: "http://packages.icinga.com/icinga.key"
+
+# The apt repository and key for debian backports
+icinga2_agent_apt_backports:
+  repo: "deb http://pkg.adfinis-sygroup.ch/mirror/{{ ansible_distribution|lower }} {{ ansible_distribution_release }}-backports main non-free contrib"

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -63,7 +63,7 @@
   package:
     name: '{{ icinga2_agent_packages }}'
     state: present
-  when: 
+  when:
     - ansible_os_family != 'RedHat'
     - ansible_distribution_release != 'stretch'
 

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -38,8 +38,8 @@
   apt_repository:
     repo: '{{ icinga2_agent_apt_backports.repo }}'
     state: present
-  when: 
-    - ansible_os_family == 'Debian' 
+  when:
+    - ansible_os_family == 'Debian'
     - ansible_distribution_release == 'stretch'
 
 - name: configure icinga epel repository

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -34,6 +34,14 @@
     state: present
   when: ansible_os_family == 'Debian'
 
+- name: configure debian backports repository
+  apt_repository:
+    repo: '{{ icinga2_agent_apt_backports.repo }}'
+    state: present
+  when: 
+    - ansible_os_family == 'Debian' 
+    - ansible_distribution_release == 'stretch'
+
 - name: configure icinga epel repository
   yum_repository:
     name: icinga-stable-release

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -50,11 +50,22 @@
     gpgkey: '{{ icinga2_agent_yum.key }}'
   when: ansible_os_family == 'RedHat'
 
+- name: install icinga 2 agent packages on debian stretch
+  apt:
+    name: '{{ icinga2_agent_packages }}'
+    state: present
+    default_release: 'stretch-backports'
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_release == 'stretch'
+
 - name: install icinga 2 agent packages
   package:
     name: '{{ icinga2_agent_packages }}'
     state: present
-  when: ansible_os_family != 'RedHat'
+  when: 
+    - ansible_os_family != 'RedHat'
+    - ansible_distribution_release != 'stretch'
 
 - name: install icinga 2 agent packages
   yum:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To install icinga2 on debian stretch, we need the backports repository, as it cant find the dependencies without the backports repository.

##### ISSUE TYPE
 - Bugfix Pull Request