### PR TITLE
Add backports to Debian Stretch

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,7 @@ icinga2_agent_yum:
 icinga2_agent_apt:
   repo: "deb http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main"
   key: "http://packages.icinga.com/icinga.key"
+
+# The apt repository for stretch-backports
+stretch_backports_apt:
+  repo: "deb http://deb.debian.org/debian stretch-backports main"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,1 +1,6 @@
 ---
+
+- name: update package repository
+  apt:
+    update_cache: yes
+  when: ansible_os_family == 'Debian'

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -33,6 +33,19 @@
     repo: '{{ icinga2_agent_apt.repo }}'
     state: present
   when: ansible_os_family == 'Debian'
+  notify: update package repository
+
+- name: configure stretch-backports repository
+  apt_repository:
+    repo: '{{ stretch_backports_apt.repo }}'
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_major_version == '9'
+  notify: update package repository
+
+- name: flush handlers
+  meta: flush_handlers
 
 - name: configure icinga epel repository
   yum_repository:


### PR DESCRIPTION
`icinga2` › `icinga2-bin` › `libboost-context1.67.0` et al are only available in stretch-backports.

**Note**: These changes were written before I have discovered #7, but I considered adding a task that only executes when Debian 9 is detected to be cleaner than adding an "alternative" task for only Debian 9 (and then adding an exclusion check to the original task). Additionally, this variant makes sure that the package repos are up-to-date after adding them in apt's configuration.