### PR TITLE
Distribution support/oraclelinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This role requires the EPEL repositories to be configured on the target
 system. The following role is suggested:
 [adfinis-sygroup.pkg\_mirror](https://galaxy.ansible.com/adfinis-sygroup/pkg_mirror)
 
+On RHEL and OracleLinux the optional repo needs to be configured on the target system as well.
+
 Role Variables
 --------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,6 @@ icinga2_agent_apt:
 # The apt repository for stretch-backports
 stretch_backports_apt:
   repo: "deb http://deb.debian.org/debian stretch-backports main"
+
+# The yum repo for dependencies
+icinga2_agent_packages_enablerepo: epel

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -64,7 +64,7 @@
 - name: install icinga 2 agent packages
   yum:
     name: '{{ icinga2_agent_packages }}'
-    enablerepo: epel
+    enablerepo: '{{ icinga2_agent_packages_enablerepo }}'
     state: present
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   include_vars: '{{ item }}'
   with_first_found:
     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_distribution }}.yml'
     - '{{ ansible_os_family }}.yml'
   tags:
     - 'role::icinga2_agent'

--- a/vars/OracleLinux.yml
+++ b/vars/OracleLinux.yml
@@ -3,6 +3,7 @@ icinga2_agent_packages:
   - icinga2
   - icinga2-selinux
   - nagios-plugins-all
+
 icinga2_agent_packages_enablerepo:
   - epel
-  - rhel-7-server-optional-rpms
+  - ol7_optional_latest


### PR DESCRIPTION
##### SUMMARY
Added OracleLinux support. The optional repo needs to be enabled for the installation of perl-Dist-CheckConflicts which is a dependency nagios-plugins-disk_smb. 

Same is true for RHEL, where the package is also in the optional repo. On CentOS the package is located in the base repo.

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
ansible 2.9.4                                                                                              
  config file = /home/alexanderh/git/monitoring-plays/ansible.cfg                                          
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible                                
  executable location = /usr/bin/ansible                                                                   
  python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]                                     
```
