### PR TITLE
Fixes name schema typo at RedHat var

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 icinga2_agent_packages:
   - icinga2
   - icinga2-selinux
-  - nagios-plugins-all
+  - monitoring-plugins-all
 icinga2_agent_packages_enablerepo:
   - epel
   - rhel-7-server-optional-rpms


### PR DESCRIPTION
rpm based distros are using monitoring-plugins as name schema

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #3

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
This pull request just fixes a  name schema issue. Because deb based distros are using "nagios-plugins" and rpm based distros are using "monitoring-plugins"
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```