### PR TITLE
Univention Icinga2 Repos

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -41,7 +41,7 @@
     state: present
   when:
     - ansible_os_family == 'Debian'
-    - ansible_distribution_major_version == '9'
+    - ansible_distribution_release == 'stretch'
   notify: update package repository
 
 - name: flush handlers

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -32,7 +32,9 @@
   apt_repository:
     repo: '{{ icinga2_agent_apt.repo }}'
     state: present
-  when: ansible_os_family == 'Debian'
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_lsb.id != 'Univention'
   notify: update package repository
 
 - name: configure stretch-backports repository


### PR DESCRIPTION
##### SUMMARY

- Install Debian Stretch Backports on Stretch based Univention systems
- Do not install Icinga apt repo on Univention systems

Univention example Ansible vars:
```
"ansible_distribution": "Debian",
"ansible_distribution_major_version": "4",
"ansible_distribution_release": "stretch",
"ansible_distribution_version": "4.4-6 errata780",
"ansible_os_family": "Debian",
"ansible_lsb": {
    "codename": "Blumenthal",
    "description": "Univention Corporate Server 4.4-6 errata780 (Blumenthal)",
    "id": "Univention",
    "major_release": "4",
    "release": "4.4-6 errata780"
}
```

##### ISSUE TYPE
 - Bugfix Pull Request