### PR TITLE
Add debian support

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: install dependencies for debian-based distributions
+  apt:
+    name: ' {{ item }}'
+    state: present
+  loop: icinga2_agent_debian_dependencies
+  when: ansible_distribution == 'Debian'
+
 - name: install fedora epel repository
   yum:
     name: 'https://pkg.adfinis-sygroup.ch/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,8 @@
 ---
 
+icinga2_agent_debian_dependencies:
+  - gnupg2
+
 icinga2_agent_packages:
   - icinga2
   - nagios-plugins


### PR DESCRIPTION
##### SUMMARY
Debian needs the gnupg2 package so GPG keys can be installed.
This effectively provides debian support for the entire role.


##### ISSUE TYPE
 - Feature Pull Request


##### ANSIBLE VERSION
```
ansible [core 2.11.1] 
```